### PR TITLE
Enrich displacement pulse and mixer_correction

### DIFF
--- a/qtrlb/calibration/mixer_correction.py
+++ b/qtrlb/calibration/mixer_correction.py
@@ -312,10 +312,11 @@ class MixerAutoCorrection(MixerCorrection):
         It will be triggered when we change ref_level from 0 dBm to higher.
         """
         # A wide span with all three peaks on screen.
+        self.sa.set('continuous_sweep', 'ON')
         self.sa.set('freq_center', self.lo_freq)
         self.sa.set('freq_span', 2.4 * abs(self.mod_freq))
         self.sa.set('res_bw', abs(self.mod_freq) * 2e-4)
-        self.sa.set('vid_bw_auto')
+        self.sa.set('vid_bw_auto', 'ON')
         self.sa.set('ref_level', '20')
 
         # Set three markers on three peaks.

--- a/qtrlb/utils/N9010A.py
+++ b/qtrlb/utils/N9010A.py
@@ -29,6 +29,7 @@ class N9010A:
         'excursion_status': ':CALCulate:MARKer:PEAK:EXCursion:STATe',
         'threshold': ':CALCulate:MARKer:PEAK:THReshold',
         'threshold_status': ':CALCulate:MARKer:PEAK:THReshold:STATe',
+        'continuous_sweep':'INIT:CONT',
         'sweep_points': ':SWEep:POINts'
     }    
 
@@ -47,7 +48,7 @@ class N9010A:
 
     def __init__(self, ip_address: str = '192.168.1.14'):
         self.ip_address = ip_address
-        self.resource_name = f'TCPIP0::{self.ip_address}::INSTR'
+        self.resource_name = f'TCPIP0::{self.ip_address}::inst0::INSTR'
         self.inst = pyvisa.ResourceManager().open_resource(self.resource_name)
 
 


### PR DESCRIPTION
In this PR, we add more detail and option in displacement pulse. We also enable switching between continuous and single measurement sweep mode of N9010A driver.